### PR TITLE
feat: add diary API with backdate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ Refer to the documentation for installation, usage and development instructions.
 
 # Disclaimer
 This project and its authors are not affiliated with Serializd. The API used by this package, based on official web and Android apps, is not official and is subject to change without notice.
+
+# AI Attribution (Fork Feature)
+
+The diary entry with custom date feature (`log_episode_to_diary()`, `DiaryEntryRequest`) in the `feature/diary-with-date` branch was developed with AI assistance.
+
+- **AI Tool**: Claude Opus 4.5 (Anthropic)
+- **Human Oversight**: All code was reviewed and tested by a human developer
+- **Commits**: AI-assisted commits include the `Co-authored-by: Claude <noreply@anthropic.com>` trailer
+
+This disclosure is provided in accordance with best practices for AI transparency in open source development.

--- a/serializd/__init__.py
+++ b/serializd/__init__.py
@@ -1,3 +1,4 @@
 from serializd.client import SerializdClient
+from serializd.models.actions import DiaryEntryRequest
 
-__all__ = ['SerializdClient']
+__all__ = ['SerializdClient', 'DiaryEntryRequest']

--- a/serializd/client.py
+++ b/serializd/client.py
@@ -286,7 +286,7 @@ class SerializdClient:
         )
         if not resp.is_success:
             self.logger.error(
-                'Failed to log epsiodes of season ID %d (show ID %d) as watched!',
+                'Failed to log episodes %s of season ID %d (show ID %d) as watched!',
                 episode_numbers, season_id, show_id
             )
             self._parse_response(resp)
@@ -323,7 +323,7 @@ class SerializdClient:
         )
         if not resp.is_success:
             self.logger.error(
-                'Failed to unlog epsiodes of season ID %d (show ID %d) as watched!',
+                'Failed to unlog episodes %s of season ID %d (show ID %d) as watched!',
                 episode_numbers, season_id, show_id
             )
             self._parse_response(resp)

--- a/serializd/client.py
+++ b/serializd/client.py
@@ -517,6 +517,29 @@ class SerializdClient:
 
         return all_entries
 
+    def delete_diary_entry(self, review_id: int) -> bool:
+        """
+        Deletes a diary entry (review) by ID.
+
+        Args:
+            review_id: The ID of the diary entry/review to delete
+
+        Returns:
+            True if deletion was successful, False otherwise.
+
+        Raises:
+            SerializdError: Serializd returned an error
+        """
+        resp = self.session.post(
+            '/show/reviews/delete',
+            json={'review_id': review_id}
+        )
+        if not resp.is_success:
+            self.logger.error('Failed to delete diary entry %d!', review_id)
+            return False
+        
+        return True
+
     def _parse_response(
         self,
         resp: httpx.Response,

--- a/serializd/client.py
+++ b/serializd/client.py
@@ -370,15 +370,21 @@ class SerializdClient:
         # First, mark the episode as watched using episode_log/add
         # This ensures the episode shows up in the watched list, not just the diary
         if mark_as_watched:
-            watched_success = self.log_episodes(
-                show_id=show_id,
-                season_id=season_id,
-                episode_numbers=[episode_number]
-            )
-            if not watched_success:
+            try:
+                watched_success = self.log_episodes(
+                    show_id=show_id,
+                    season_id=season_id,
+                    episode_numbers=[episode_number]
+                )
+                if not watched_success:
+                    self.logger.warning(
+                        'Failed to mark episode %d as watched, continuing with diary entry',
+                        episode_number
+                    )
+            except Exception as e:
                 self.logger.warning(
-                    'Failed to mark episode %d as watched, continuing with diary entry',
-                    episode_number
+                    'Error marking episode %d as watched (%s), continuing with diary entry',
+                    episode_number, str(e)
                 )
 
         # Then add to diary with the specific date

--- a/serializd/client.py
+++ b/serializd/client.py
@@ -339,7 +339,8 @@ class SerializdClient:
         watched_at: str,
         is_rewatch: bool = False,
         rating: int = 0,
-        review_text: str = ""
+        review_text: str = "",
+        mark_as_watched: bool = True
     ) -> bool:
         """
         Adds an episode to the user's diary with a specific watch date.
@@ -358,6 +359,7 @@ class SerializdClient:
             is_rewatch: Whether this is a rewatch of a previously seen episode
             rating: Optional rating (0-10, 0 means no rating)
             review_text: Optional review text
+            mark_as_watched: Also mark the episode as watched (default: True)
 
         Returns:
             Success status.
@@ -365,6 +367,21 @@ class SerializdClient:
         Raises:
             SerializdError: Serializd returned an error
         """
+        # First, mark the episode as watched using episode_log/add
+        # This ensures the episode shows up in the watched list, not just the diary
+        if mark_as_watched:
+            watched_success = self.log_episodes(
+                show_id=show_id,
+                season_id=season_id,
+                episode_numbers=[episode_number]
+            )
+            if not watched_success:
+                self.logger.warning(
+                    'Failed to mark episode %d as watched, continuing with diary entry',
+                    episode_number
+                )
+
+        # Then add to diary with the specific date
         params = DiaryEntryRequest(
             show_id=show_id,
             season_id=season_id,

--- a/serializd/client.py
+++ b/serializd/client.py
@@ -146,7 +146,7 @@ class SerializdClient:
         resp = self.session.get(f'/show/{show_id}/season/{season_number}')
         if not resp.is_success:
             self.logger.error(
-                'Failed to fetch season information for show ID %d, season %02d!',
+                'Failed to fetch season information for show ID %s, season %s!',
                 show_id, season_number
             )
 

--- a/serializd/models/actions.py
+++ b/serializd/models/actions.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from datetime import datetime
+
+from pydantic import BaseModel, Field
 
 
 class LogSeasonsRequest(BaseModel):
@@ -23,3 +25,59 @@ class UnlogEpisodesRequest(BaseModel):
     episode_numbers: list[int]
     season_id: int
     show_id: int
+
+
+class DiaryEntryRequest(BaseModel):
+    """Request model for adding an episode to diary with custom date.
+    
+    Uses the /show/reviews/add endpoint which supports backdating entries.
+    """
+    show_id: int
+    season_id: int
+    episode_number: int
+    backdate: str = Field(
+        ...,
+        description="ISO 8601 formatted datetime string (e.g., '2025-06-15T12:00:00Z')"
+    )
+    review_text: str = ""
+    rating: int = Field(default=0, ge=0, le=10)
+    contains_spoiler: bool = False
+    is_log: bool = True
+    is_rewatch: bool = False
+    tags: list[str] = Field(default_factory=list)
+    allows_comments: bool = True
+    like: bool = False
+    
+    @classmethod
+    def from_watch_data(
+        cls,
+        show_id: int,
+        season_id: int,
+        episode_number: int,
+        watched_at: datetime | str,
+        is_rewatch: bool = False
+    ) -> DiaryEntryRequest:
+        """Create a diary entry from watch history data.
+        
+        Args:
+            show_id: Serializd show ID
+            season_id: Serializd season ID  
+            episode_number: Episode number in the season
+            watched_at: When the episode was watched (datetime or ISO string)
+            is_rewatch: Whether this is a rewatch
+            
+        Returns:
+            DiaryEntryRequest configured for logging a watched episode
+        """
+        if isinstance(watched_at, datetime):
+            backdate = watched_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+        else:
+            backdate = watched_at
+            
+        return cls(
+            show_id=show_id,
+            season_id=season_id,
+            episode_number=episode_number,
+            backdate=backdate,
+            is_rewatch=is_rewatch
+        )


### PR DESCRIPTION
Closes #2

Adds methods for interacting with Serializd's diary feature:

**New methods:**
- `log_episode_to_diary(show_id, season, episode, date)` — log an episode with optional date (defaults to today)
- `get_user_diary(username, page)` — fetch diary entries (paginated)
- `get_all_diary_entries(username)` — fetch all diary entries
- `delete_diary_entry(review_id)` — remove a diary entry
- `get_user_show_progress(username, show_id)` — get watched episodes for a show
- `is_episode_watched(username, show_id, season, episode)` — check if episode is marked watched

---
**Note:** I used Claude Opus 4.5 for this. All commits include `Co-authored-by: Claude` trailers for transparency. I completely understand if you prefer not to merge AI-assisted contributions, though.